### PR TITLE
Allow VenoBox to be installed via bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "venobox",
-  "version": "0.1.0",
+  "version": "1.2.2",
   "homepage": "http://lab.veno.it/venobox/",
   "authors": [
     "Nicola Franchini"


### PR DESCRIPTION
Hi Nicola,

We use [bower](http://bower.io/) to install all of our 3rd party plugins. I created a bower file for you and marked the version as `1.2.2`.

If you accept this pull request please do the following:
1. Create a tag and push it

```
git tag -a v1.2.2 -m 'Release 1.2.2'
git push origin --tags
```
1. Register the package with bower

```
bower register venobox git@github.com:nicolafranchini/VenoBox.git
```

Once that is done your project should be available on the bower registry:
http://sindresorhus.com/bower-components/

If you need any assistance please let me know.

Cheers,

Ryan
