### PR TITLE
Check if transition is on the overlay

### DIFF
--- a/venobox/venobox.js
+++ b/venobox/venobox.js
@@ -104,6 +104,7 @@
                       });
                     } else {
                       overlay.bind("transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd", function(){
+                        if(overlay[0] != e.target) { return; }
                         overlay.css({
                           'min-height': $(window).outerHeight(),
                           height : 'auto'


### PR DESCRIPTION
Hi,

I found a bug with your plugin: at some points in your code you check for the `transitionend`-event to trigger a load-action (`loadIframe()`, `loadInline()`, etc.). But... if the content loaded also contains transitions, this event gets triggered again, causing the content of the lightbox to reload as soon as the transition in the content in the lightbox is completed.

Adding a simple check solves this issue. I've done this now on one place, but I can imagine this problem occurs on more than one place in your source code.
