### PR TITLE
Prevent double initialization

### DIFF
--- a/venobox/venobox.js
+++ b/venobox/venobox.js
@@ -31,6 +31,10 @@
             return this.each(function() {
                   var obj = $(this);
 
+                  if(obj.data('venobox')) {
+                  	return true;
+                  }
+
                   obj.addClass('vbox-item');
                   obj.data('framewidth', options.framewidth);
                   obj.data('frameheight', options.frameheight);
@@ -38,6 +42,7 @@
                   obj.data('bgcolor', options.bgcolor);
                   obj.data('numeratio', options.numeratio);
                   obj.data('infinigall', options.infinigall);
+                  obj.data('venobox', true);
 
                   ios = (navigator.userAgent.match(/(iPad|iPhone|iPod)/g) ? true : false);
 


### PR DESCRIPTION
Calling venobox() more than once will create multiple click handlers.

This fix sets a data attribute on each item to mark it as initialized. The initialization loop will ignore the item when called multiple times.
