### PR TITLE
Specify a different url to be loaded via ajax

### DIFF
--- a/venobox/venobox.js
+++ b/venobox/venobox.js
@@ -69,7 +69,7 @@
                     nextok = false;
                     prevok = false;
                     keyNavigationDisabled = false;
-                    dest = obj.attr('href');
+                    dest = obj.data('href') || obj.attr('href');
                     top = $(window).scrollTop();
                     top = -top;
                     extraCss = obj.data( 'css' ) || "";


### PR DESCRIPTION
Sometimes, the url to be loaded via ajax cannot be the same as the one in the href attribute.
For such cases, this simple tweak allows to specify a different url to be used for Destination.
Example:
`<a href="http://google.be" data-href="http://microsoft.com">test</a>`