### PR TITLE
Update to CSS file to fix images stretching to 100% of Container

### DIFF
--- a/venobox/venobox.css
+++ b/venobox/venobox.css
@@ -324,6 +324,6 @@
 .vbox-container img{
     max-width: 100%;
     width: auto;
-    max-height: 100% !important;
+    max-height: 100%;
     height: auto;
 }

--- a/venobox/venobox.css
+++ b/venobox/venobox.css
@@ -323,5 +323,7 @@
 }
 .vbox-container img{
     max-width: 100%;
+    width: auto;
+    max-height: 100% !important;
     height: auto;
 }


### PR DESCRIPTION
When viewing images in the lightbox they were being stretched to 100% of the Container.

So the changes I have made keep the img at the actual size rather than stretching it.
