### PR TITLE
Fixing "Uncaught TypeError: Cannot read property 'nodeType' of undefined"

### DIFF
--- a/venobox/venobox.js
+++ b/venobox/venobox.js
@@ -395,7 +395,7 @@
 
                     autoplay = destination.data('autoplay');
 
-                    title = destination.attr(destination.data('titleattr')) || '';
+                    title = (destination.data('titleattr') && destination.attr(destination.data('titleattr'))) || '';
 
                     // swipe out item
                     if (destination === theprev) {


### PR DESCRIPTION
Experimenting with custom gallery items just now, I found that when trying to navigate from the first item I would get the following error:

```
Uncaught TypeError: Cannot read property 'nodeType' of undefined
    at jQuery.fn.init.attr (jquery.js:7744)
    at access (jquery.js:3991)
    at jQuery.fn.init.attr (jquery.js:7731)
    at navigateGall (venobox.js:399)
    at HTMLAnchorElement.<anonymous> (venobox.js:305)
    at HTMLAnchorElement.dispatch (jquery.js:5233)
    at HTMLAnchorElement.elemData.handle (jquery.js:5040)
```

It seemed to be coming from line 398 – if I add the `data-titleattr` property to the anchor element in question, the error no longer occurs.

Thus I have made a minor modification to check for the presence of `data-titleattr` before attempting to pass its value to `.attr()`.

This was with jQuery 3.4.0. Note that I have not re-minified the Venobox code after making this tweak.

Thanks for the awesome library!