### PR TITLE
Add youtube-nocookie.com to parseVideo

### DIFF
--- a/venobox/venobox.js
+++ b/venobox/venobox.js
@@ -713,7 +713,7 @@
                 * Parse Youtube or Vimeo videos and get host & ID
                 */
                 function parseVideo (url) {
-                    url.match(/(http:|https:|)\/\/(player.|www.)?(vimeo\.com|youtu(be\.com|\.be|be\.googleapis\.com))\/(video\/|embed\/|watch\?v=|v\/)?([A-Za-z0-9._%-]*)(\&\S+)?/);
+                    url.match(/(http:|https:|)\/\/(player.|www.)?(vimeo\.com|youtu(be\.com|\.be|be\.googleapis\.com|be\-nocookie\.com))\/(video\/|embed\/|watch\?v=|v\/)?([A-Za-z0-9._%-]*)(\&\S+)?/);
                     var type;
                     if (RegExp.$3.indexOf('youtu') > -1) {
                         type = 'youtube';


### PR DESCRIPTION
Allow users to use 'youtube-nocookie' URLs. It loads videos faster, and is GPDR friendly/compliant.